### PR TITLE
Disallow freezing the zero address

### DIFF
--- a/src/token/RestrictionManager.sol
+++ b/src/token/RestrictionManager.sol
@@ -71,6 +71,7 @@ contract RestrictionManager is Auth {
 
     // --- Handling freezes ---
     function freeze(address user) public auth {
+        require(user != address(0), "RestrictionManager/cannot-freeze-zero-address");
         frozen[user] = 1;
         emit Freeze(user);
     }

--- a/test/token/RestrictionManager.t.sol
+++ b/test/token/RestrictionManager.t.sol
@@ -27,4 +27,15 @@ contract RestrictionManagerTest is Test {
         restrictionManager.updateMember(address(this), validUntil);
         assert(restrictionManager.hasMember(address(this)));
     }
+
+    function testFreeze() public {
+        restrictionManager.freeze(address(this));
+        assertEq(restrictionManager.frozen(address(this)), 1);
+    }
+
+    function testFreezingZeroAddress() public {
+        vm.expectRevert("RestrictionManager/cannot-freeze-zero-address");
+        restrictionManager.freeze(address(0));
+        assertEq(restrictionManager.frozen(address(0)), 0);
+    }
 }


### PR DESCRIPTION
This PR adds a `require` to the `RestrictionManager` disallowing `address(0)` to be frozen.