### PR TITLE
Make restrictionManagerFactory mutable on PoolManager

### DIFF
--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -78,8 +78,8 @@ contract PoolManager is Auth {
 
     EscrowLike public immutable escrow;
     LiquidityPoolFactoryLike public immutable liquidityPoolFactory;
-    RestrictionManagerFactoryLike public immutable restrictionManagerFactory;
     TrancheTokenFactoryLike public immutable trancheTokenFactory;
+    RestrictionManagerFactoryLike public restrictionManagerFactory;
 
     GatewayLike public gateway;
     InvestmentManagerLike public investmentManager;
@@ -137,6 +137,7 @@ contract PoolManager is Auth {
     function file(bytes32 what, address data) external auth {
         if (what == "gateway") gateway = GatewayLike(data);
         else if (what == "investmentManager") investmentManager = InvestmentManagerLike(data);
+        else if (what == "restrictionManagerFactory") restrictionManagerFactory = RestrictionManagerFactoryLike(data);
         else revert("PoolManager/file-unrecognized-param");
         emit File(what, data);
     }

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -79,8 +79,8 @@ contract PoolManager is Auth {
     EscrowLike public immutable escrow;
     LiquidityPoolFactoryLike public immutable liquidityPoolFactory;
     TrancheTokenFactoryLike public immutable trancheTokenFactory;
-    RestrictionManagerFactoryLike public restrictionManagerFactory;
 
+    RestrictionManagerFactoryLike public restrictionManagerFactory;
     GatewayLike public gateway;
     InvestmentManagerLike public investmentManager;
 

--- a/test/PoolManager.t.sol
+++ b/test/PoolManager.t.sol
@@ -4,6 +4,25 @@ pragma solidity 0.8.21;
 import "./TestSetup.t.sol";
 
 contract PoolManagerTest is TestSetup {
+
+    function testFile() public {
+        address newGateway = makeAddr("newGateway");
+        poolManager.file("gateway", newGateway);
+        assertEq(address(poolManager.gateway()), newGateway);
+
+        address newInvestmentManager = makeAddr("newInvestmentManager");
+        poolManager.file("investmentManager", newInvestmentManager);
+        assertEq(address(poolManager.investmentManager()), newInvestmentManager);
+
+        address newRestrictionManagerFactory = makeAddr("newRestrictionManagerFactory");
+        poolManager.file("restrictionManagerFactory", newRestrictionManagerFactory);
+        assertEq(address(poolManager.restrictionManagerFactory()), newRestrictionManagerFactory);
+
+        address newEscrow = makeAddr("newEscrow");
+        vm.expectRevert("PoolManager/file-unrecognized-param");
+        poolManager.file("escrow", newEscrow);
+    }
+
     // Deployment
     function testDeployment() public {
         // values set correctly


### PR DESCRIPTION
Since it's possible the `RestrictionManager` contract will need to be updated some day, this PR makes `restrictionManagerFactory` a mutable variable on the `PoolManager` and adds a case for it in the `file` function. This way the pool manager won't need to be migrated in the case where the `RestrictionManager` is updated.