### PR TITLE
Assume nonWard is not aggregator

### DIFF
--- a/test/unit/gateway/Gateway.t.sol
+++ b/test/unit/gateway/Gateway.t.sol
@@ -7,7 +7,10 @@ import "test/mocks/MockManager.sol";
 contract GatewayTest is BaseTest {
     // Deployment
     function testDeployment(address nonWard) public {
-        vm.assume(nonWard != address(root) && nonWard != address(delayedAdmin) && nonWard != address(this) && nonWard != address(aggregator));
+        vm.assume(
+            nonWard != address(root) && nonWard != address(delayedAdmin) && nonWard != address(this)
+                && nonWard != address(aggregator)
+        );
 
         // values set correctly
         assertEq(address(gateway.investmentManager()), address(investmentManager));

--- a/test/unit/gateway/Gateway.t.sol
+++ b/test/unit/gateway/Gateway.t.sol
@@ -7,7 +7,7 @@ import "test/mocks/MockManager.sol";
 contract GatewayTest is BaseTest {
     // Deployment
     function testDeployment(address nonWard) public {
-        vm.assume(nonWard != address(root) && nonWard != address(delayedAdmin) && nonWard != address(this));
+        vm.assume(nonWard != address(root) && nonWard != address(delayedAdmin) && nonWard != address(this) && nonWard != address(aggregator));
 
         // values set correctly
         assertEq(address(gateway.investmentManager()), address(investmentManager));


### PR DESCRIPTION
I noticed the fuzzer would sometimes fail because we're not assuming `nonWard != aggregator`