### PR TITLE
Consistent mocks naming

### DIFF
--- a/test/mocks/MockAxelarGateway.sol
+++ b/test/mocks/MockAxelarGateway.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import "./Mock.sol";
 
-contract AxelarGatewayMock is Mock {
+contract MockAxelarGateway is Mock {
     constructor() {}
 
     function validateContractCall(bytes32, string calldata, string calldata, bytes32) public view returns (bool) {

--- a/test/mocks/MockAxelarPrecompile.sol
+++ b/test/mocks/MockAxelarPrecompile.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import "./Mock.sol";
 
-contract AxelarPrecompileMock is Mock {
+contract MockAxelarPrecompile is Mock {
     constructor() {}
 
     function execute(

--- a/test/mocks/MockGateway.sol
+++ b/test/mocks/MockGateway.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import "./Mock.sol";
 
-contract GatewayMock is Mock {
+contract MockGateway is Mock {
     mapping(bytes => uint256) public handled;
 
     constructor() {}

--- a/test/mocks/MockRestrictionManager.sol
+++ b/test/mocks/MockRestrictionManager.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.21;
 import "./Mock.sol";
 import "../../src/token/RestrictionManager.sol";
 
-contract RestrictionManagerMock is RestrictionManager, Mock {
+contract MockRestrictionManager is RestrictionManager, Mock {
     constructor(address token_) RestrictionManager(token_) {}
 
     // --- Misc ---

--- a/test/mocks/MockRestrictionManagerFactory.sol
+++ b/test/mocks/MockRestrictionManagerFactory.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import "./Mock.sol";
 
-contract RestrictionManagerFactoryMock is Mock {
+contract RestrictionManagerFactory is Mock {
     function newRestrictionManager(
         uint8 restrictionSet,
         address, /* token */

--- a/test/mocks/MockRestrictionManagerFactory.sol
+++ b/test/mocks/MockRestrictionManagerFactory.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import "./Mock.sol";
 
-contract RestrictionManagerFactory is Mock {
+contract MockRestrictionManagerFactory is Mock {
     function newRestrictionManager(
         uint8 restrictionSet,
         address, /* token */

--- a/test/mocks/MockSucceedingRequestReceiver.sol
+++ b/test/mocks/MockSucceedingRequestReceiver.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.21;
 import "./Mock.sol";
 import {IERC7540DepositReceiver, IERC7540RedeemReceiver} from "../../src/interfaces/IERC7540.sol";
 
-contract SucceedingRequestReceiver is IERC7540DepositReceiver, IERC7540RedeemReceiver, Mock {
+contract MockSucceedingRequestReceiver is IERC7540DepositReceiver, IERC7540RedeemReceiver, Mock {
     function onERC7540DepositReceived(
         address _operator,
         address _owner,

--- a/test/unit/ERC7540Vault.t.sol
+++ b/test/unit/ERC7540Vault.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.21;
 import "test/BaseTest.sol";
 import "src/interfaces/IERC7575.sol";
 import "src/interfaces/IERC7540.sol";
-import {SucceedingRequestReceiver} from "test/mocks/SucceedingRequestReceiver.sol";
+import {MockSucceedingRequestReceiver} from "test/mocks/MockSucceedingRequestReceiver.sol";
 import {FailingRequestReceiver} from "test/mocks/FailingRequestReceiver.sol";
 
 contract ERC7540VaultTest is BaseTest {
@@ -128,7 +128,7 @@ contract ERC7540VaultTest is BaseTest {
 
         address vault_ = deploySimpleVault();
         ERC7540Vault vault = ERC7540Vault(vault_);
-        SucceedingRequestReceiver receiver = new SucceedingRequestReceiver();
+        MockSucceedingRequestReceiver receiver = new MockSucceedingRequestReceiver();
 
         centrifugeChain.updateMember(vault.poolId(), vault.trancheId(), address(receiver), type(uint64).max);
         centrifugeChain.updateMember(vault.poolId(), vault.trancheId(), self, type(uint64).max);
@@ -179,7 +179,7 @@ contract ERC7540VaultTest is BaseTest {
     function testSucceedingCallbacksNotCalledWithEmptyData() public {
         address vault_ = deploySimpleVault();
         ERC7540Vault vault = ERC7540Vault(vault_);
-        SucceedingRequestReceiver receiver = new SucceedingRequestReceiver();
+        MockSucceedingRequestReceiver receiver = new MockSucceedingRequestReceiver();
 
         centrifugeChain.updateMember(vault.poolId(), vault.trancheId(), address(receiver), type(uint64).max);
         centrifugeChain.updateMember(vault.poolId(), vault.trancheId(), self, type(uint64).max);

--- a/test/unit/PoolManager.t.sol
+++ b/test/unit/PoolManager.t.sol
@@ -164,7 +164,7 @@ contract PoolManagerTest is BaseTest {
     }
 
     function testRestrictionSetIntegration(uint64 poolId, bytes16 trancheId, uint8 restrictionSet) public {
-        RestrictionManagerFactory restrictionManagerFactory = new RestrictionManagerFactory();
+        MockRestrictionManagerFactory restrictionManagerFactory = new MockRestrictionManagerFactory();
         poolManager.file("restrictionManagerFactory", address(restrictionManagerFactory));
         centrifugeChain.addPool(poolId);
         centrifugeChain.addTranche(poolId, trancheId, "", "", defaultDecimals, restrictionSet);

--- a/test/unit/PoolManager.t.sol
+++ b/test/unit/PoolManager.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.21;
 
 import "test/BaseTest.sol";
-import "test/mocks/RestrictionManagerFactory.sol";
+import "test/mocks/MockRestrictionManagerFactory.sol";
 import {CastLib} from "src/libraries/CastLib.sol";
 
 contract PoolManagerTest is BaseTest {
@@ -164,7 +164,7 @@ contract PoolManagerTest is BaseTest {
     }
 
     function testRestrictionSetIntegration(uint64 poolId, bytes16 trancheId, uint8 restrictionSet) public {
-        RestrictionManagerFactoryMock restrictionManagerFactory = new RestrictionManagerFactoryMock();
+        RestrictionManagerFactory restrictionManagerFactory = new RestrictionManagerFactory();
         poolManager.file("restrictionManagerFactory", address(restrictionManagerFactory));
         centrifugeChain.addPool(poolId);
         centrifugeChain.addTranche(poolId, trancheId, "", "", defaultDecimals, restrictionSet);

--- a/test/unit/gateway/routers/Aggregator.t.sol
+++ b/test/unit/gateway/routers/Aggregator.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import "test/BaseTest.sol";
 import {Aggregator} from "src/gateway/routers/Aggregator.sol";
-import {GatewayMock} from "test/mocks/GatewayMock.sol";
+import {MockGateway} from "test/mocks/MockGateway.sol";
 import {MockRouter} from "test/mocks/MockRouter.sol";
 import {CastLib} from "src/libraries/CastLib.sol";
 
@@ -11,7 +11,7 @@ contract AggregatorTest is Test {
     using CastLib for *;
 
     Aggregator aggregator;
-    GatewayMock gateway;
+    MockGateway gateway;
     MockRouter router1;
     MockRouter router2;
     MockRouter router3;
@@ -22,7 +22,7 @@ contract AggregatorTest is Test {
     address[] nineMockRouters;
 
     function setUp() public {
-        gateway = new GatewayMock();
+        gateway = new MockGateway();
         aggregator = new Aggregator(address(gateway));
 
         router1 = new MockRouter(address(aggregator));

--- a/test/unit/gateway/routers/axelar/Forwarder.t.sol
+++ b/test/unit/gateway/routers/axelar/Forwarder.t.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
-import {AxelarPrecompileMock} from "test/mocks/AxelarPrecompileMock.sol";
-import {AxelarGatewayMock} from "test/mocks/AxelarGatewayMock.sol";
+import {MockAxelarPrecompile} from "test/mocks/MockAxelarPrecompile.sol";
+import {MockAxelarGateway} from "test/mocks/MockAxelarGateway.sol";
 import {AxelarForwarder} from "src/gateway/routers/axelar/Forwarder.sol";
 
 contract AxelarForwarderTest is Test {
@@ -11,13 +11,13 @@ contract AxelarForwarderTest is Test {
     // 0x0000000000000000000000000000000000000800 in hex.
     address internal constant PRECOMPILE = 0x0000000000000000000000000000000000000800;
 
-    AxelarPrecompileMock precompile = AxelarPrecompileMock(PRECOMPILE);
-    AxelarGatewayMock axelarGateway;
+    MockAxelarPrecompile precompile = MockAxelarPrecompile(PRECOMPILE);
+    MockAxelarGateway axelarGateway;
     AxelarForwarder forwarder;
 
     function setUp() public {
-        vm.etch(PRECOMPILE, address(new AxelarPrecompileMock()).code);
-        axelarGateway = new AxelarGatewayMock();
+        vm.etch(PRECOMPILE, address(new MockAxelarPrecompile()).code);
+        axelarGateway = new MockAxelarGateway();
         forwarder = new AxelarForwarder(address(axelarGateway));
     }
 

--- a/test/unit/gateway/routers/axelar/Router.t.sol
+++ b/test/unit/gateway/routers/axelar/Router.t.sol
@@ -3,14 +3,14 @@ pragma solidity 0.8.21;
 
 import "forge-std/Test.sol";
 import {AxelarRouter} from "src/gateway/routers/axelar/Router.sol";
-import {AxelarGatewayMock} from "test/mocks/AxelarGatewayMock.sol";
-import {GatewayMock} from "test/mocks/GatewayMock.sol";
+import {MockAxelarGateway} from "test/mocks/MockAxelarGateway.sol";
+import {MockGateway} from "test/mocks/MockGateway.sol";
 import {AxelarForwarder} from "src/gateway/routers/axelar/Forwarder.sol";
 import {BytesLib} from "src/libraries/BytesLib.sol";
 
 contract AxelarRouterTest is Test {
-    AxelarGatewayMock axelarGateway;
-    GatewayMock gateway;
+    MockAxelarGateway axelarGateway;
+    MockGateway gateway;
     AxelarRouter router;
     AxelarForwarder forwarder;
 
@@ -18,8 +18,8 @@ contract AxelarRouterTest is Test {
     string private constant axelarCentrifugeChainAddress = "0x7369626CEF070000000000000000000000000000";
 
     function setUp() public {
-        axelarGateway = new AxelarGatewayMock();
-        gateway = new GatewayMock();
+        axelarGateway = new MockAxelarGateway();
+        gateway = new MockGateway();
 
         forwarder = new AxelarForwarder(address(axelarGateway));
         router = new AxelarRouter(address(gateway), address(axelarGateway));

--- a/test/unit/token/Tranche.t.sol
+++ b/test/unit/token/Tranche.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.21;
 
 import {TrancheToken} from "src/token/Tranche.sol";
 import {RestrictionManagerLike} from "src/token/RestrictionManager.sol";
-import {RestrictionManagerMock} from "test/mocks/RestrictionManager.sol";
+import {MockRestrictionManager} from "test/mocks/MockRestrictionManager.sol";
 import "forge-std/Test.sol";
 
 interface ERC20Like {
@@ -12,7 +12,7 @@ interface ERC20Like {
 
 contract TrancheTokenTest is Test {
     TrancheToken token;
-    RestrictionManagerMock restrictionManager;
+    MockRestrictionManager restrictionManager;
 
     address self;
     address targetUser = makeAddr("targetUser");
@@ -25,7 +25,7 @@ contract TrancheTokenTest is Test {
         token.file("name", "Some Token");
         token.file("symbol", "ST");
 
-        restrictionManager = new RestrictionManagerMock(address(token));
+        restrictionManager = new MockRestrictionManager(address(token));
         restrictionManager.rely(address(token));
         token.file("restrictionManager", address(restrictionManager));
     }


### PR DESCRIPTION
This commit formalizes the mock naming scheme `Mock*` for all mocks.