### PR TITLE
Fix trigger redeem order with cancellations

### DIFF
--- a/src/InvestmentManager.sol
+++ b/src/InvestmentManager.sol
@@ -111,6 +111,7 @@ contract InvestmentManager is Auth, IInvestmentManager {
         return _processRedeemRequest(vault, _shares, controller, source, false);
     }
 
+    /// @dev    triggered indicates if the the _processRedeemRequest call was triggered from centrifugeChain
     function _processRedeemRequest(address vault, uint128 shares, address controller, address source, bool triggered)
         internal
         returns (bool)

--- a/src/InvestmentManager.sol
+++ b/src/InvestmentManager.sol
@@ -108,16 +108,16 @@ contract InvestmentManager is Auth, IInvestmentManager {
         // You cannot redeem using a disallowed asset, instead another vault will have to be used
         require(poolManager.isAllowedAsset(vault_.poolId(), vault_.asset()), "InvestmentManager/asset-not-allowed");
 
-        return _processRedeemRequest(vault, _shares, controller, source);
+        return _processRedeemRequest(vault, _shares, controller, source, false);
     }
 
-    function _processRedeemRequest(address vault, uint128 shares, address controller, address source)
+    function _processRedeemRequest(address vault, uint128 shares, address controller, address source, bool triggered)
         internal
         returns (bool)
     {
         IERC7540Vault vault_ = IERC7540Vault(vault);
         InvestmentState storage state = investments[vault][controller];
-        require(state.pendingCancelRedeemRequest != true, "InvestmentManager/cancellation-is-pending");
+        require(state.pendingCancelRedeemRequest != true || triggered, "InvestmentManager/cancellation-is-pending");
 
         state.pendingRedeemRequest = state.pendingRedeemRequest + shares;
 
@@ -359,7 +359,7 @@ contract InvestmentManager is Auth, IInvestmentManager {
             state.maxMint = 0;
         }
 
-        require(_processRedeemRequest(vault, shares, user, msg.sender), "InvestmentManager/failed-redeem-request");
+        require(_processRedeemRequest(vault, shares, user, msg.sender, true), "InvestmentManager/failed-redeem-request");
 
         // Transfer the tranche token amount that was not covered by tokens still in escrow for claims,
         // from user to escrow (lock tranche tokens in escrow)

--- a/test/integration/Redeem.t.sol
+++ b/test/integration/Redeem.t.sol
@@ -253,6 +253,64 @@ contract RedeemTest is BaseTest {
         assertApproxEqAbs(erc20.balanceOf(investor), investorBalanceBefore + amount, 1);
     }
 
+    function testTriggerRedeemRequestTokensWithCancellation(uint128 amount) public {
+        amount = uint128(bound(amount, 2, (MAX_UINT128 - 1)));
+        vm.assume(amount % 2 == 0);
+
+        address vault_ = deploySimpleVault();
+        ERC7540Vault vault = ERC7540Vault(vault_);
+        ITranche tranche = ITranche(address(vault.share()));
+        deposit(vault_, investor, amount, false); // request and execute deposit, but don't claim
+        uint256 investorBalanceBefore = erc20.balanceOf(investor);
+        assertEq(vault.maxMint(investor), amount);
+        uint64 poolId = vault.poolId();
+        bytes16 trancheId = vault.trancheId();
+
+        vm.prank(investor);
+        vault.mint(amount, investor); // investor mints half of the amount
+
+        assertApproxEqAbs(tranche.balanceOf(investor), amount, 1);
+        assertApproxEqAbs(tranche.balanceOf(address(escrow)), 0, 1);
+        assertApproxEqAbs(vault.maxMint(investor), 0, 1);
+
+        // investor submits request to redeem half the amount
+        vm.prank(investor);
+        vault.requestRedeem(amount / 2, investor, investor);
+        assertEq(tranche.balanceOf(address(escrow)), amount / 2);
+        assertEq(tranche.balanceOf(investor), amount / 2);
+        // investor cancels outstanding cancellation request
+        vm.prank(investor);
+        vault.cancelRedeemRequest(0, investor);
+        assertEq(vault.pendingCancelRedeemRequest(0, investor), true);
+        // redeem request can still be triggered for the other half of the investors tokens even though the investor has
+        // an outstanding cancellation
+        centrifugeChain.triggerIncreaseRedeemOrder(poolId, trancheId, investor, defaultAssetId, amount / 2);
+        assertApproxEqAbs(tranche.balanceOf(investor), 0, 1);
+        assertApproxEqAbs(tranche.balanceOf(address(escrow)), amount, 1);
+        assertEq(vault.maxMint(investor), 0);
+
+        // centrifugeChain.triggerIncreaseRedeemOrder(poolId, trancheId, investor, defaultAssetId, amount);
+
+        // assertApproxEqAbs(tranche.balanceOf(investor), 0, 1);
+        // assertApproxEqAbs(tranche.balanceOf(address(escrow)), amount, 1);
+        // assertEq(vault.maxMint(investor), 0);
+
+        // centrifugeChain.isFulfilledRedeemRequest(
+        //     vault.poolId(),
+        //     vault.trancheId(),
+        //     bytes32(bytes20(investor)),
+        //     defaultAssetId,
+        //     uint128(amount),
+        //     uint128(amount)
+        // );
+
+        // assertApproxEqAbs(tranche.balanceOf(address(escrow)), 0, 1);
+        // assertApproxEqAbs(erc20.balanceOf(address(escrow)), amount, 1);
+        // vm.prank(investor);
+        // vault.redeem(amount, investor, investor);
+        // assertApproxEqAbs(erc20.balanceOf(investor), investorBalanceBefore + amount, 1);
+    }
+
     function testTriggerRedeemRequestTokensUnmintedTokensInEscrow(uint128 amount) public {
         amount = uint128(bound(amount, 2, (MAX_UINT128 - 1)));
 

--- a/test/integration/Redeem.t.sol
+++ b/test/integration/Redeem.t.sol
@@ -279,36 +279,14 @@ contract RedeemTest is BaseTest {
         assertEq(tranche.balanceOf(address(escrow)), amount / 2);
         assertEq(tranche.balanceOf(investor), amount / 2);
         // investor cancels outstanding cancellation request
-        vm.prank(investor);
+         vm.prank(investor);
         vault.cancelRedeemRequest(0, investor);
         assertEq(vault.pendingCancelRedeemRequest(0, investor), true);
-        // redeem request can still be triggered for the other half of the investors tokens even though the investor has
-        // an outstanding cancellation
+        // redeem request can still be triggered for the other half of the investors tokens even though the investor has an outstanding cancellation
         centrifugeChain.triggerIncreaseRedeemOrder(poolId, trancheId, investor, defaultAssetId, amount / 2);
         assertApproxEqAbs(tranche.balanceOf(investor), 0, 1);
         assertApproxEqAbs(tranche.balanceOf(address(escrow)), amount, 1);
         assertEq(vault.maxMint(investor), 0);
-
-        // centrifugeChain.triggerIncreaseRedeemOrder(poolId, trancheId, investor, defaultAssetId, amount);
-
-        // assertApproxEqAbs(tranche.balanceOf(investor), 0, 1);
-        // assertApproxEqAbs(tranche.balanceOf(address(escrow)), amount, 1);
-        // assertEq(vault.maxMint(investor), 0);
-
-        // centrifugeChain.isFulfilledRedeemRequest(
-        //     vault.poolId(),
-        //     vault.trancheId(),
-        //     bytes32(bytes20(investor)),
-        //     defaultAssetId,
-        //     uint128(amount),
-        //     uint128(amount)
-        // );
-
-        // assertApproxEqAbs(tranche.balanceOf(address(escrow)), 0, 1);
-        // assertApproxEqAbs(erc20.balanceOf(address(escrow)), amount, 1);
-        // vm.prank(investor);
-        // vault.redeem(amount, investor, investor);
-        // assertApproxEqAbs(erc20.balanceOf(investor), investorBalanceBefore + amount, 1);
     }
 
     function testTriggerRedeemRequestTokensUnmintedTokensInEscrow(uint128 amount) public {

--- a/test/integration/Redeem.t.sol
+++ b/test/integration/Redeem.t.sol
@@ -279,10 +279,11 @@ contract RedeemTest is BaseTest {
         assertEq(tranche.balanceOf(address(escrow)), amount / 2);
         assertEq(tranche.balanceOf(investor), amount / 2);
         // investor cancels outstanding cancellation request
-         vm.prank(investor);
+        vm.prank(investor);
         vault.cancelRedeemRequest(0, investor);
         assertEq(vault.pendingCancelRedeemRequest(0, investor), true);
-        // redeem request can still be triggered for the other half of the investors tokens even though the investor has an outstanding cancellation
+        // redeem request can still be triggered for the other half of the investors tokens even though the investor has
+        // an outstanding cancellation
         centrifugeChain.triggerIncreaseRedeemOrder(poolId, trancheId, investor, defaultAssetId, amount / 2);
         assertApproxEqAbs(tranche.balanceOf(investor), 0, 1);
         assertApproxEqAbs(tranche.balanceOf(address(escrow)), amount, 1);


### PR DESCRIPTION
fixes the case, where redemptions orders can be triggered from centrifuge chain even though investors have outstanding redeem order cancellations