### PR TITLE
Add more router tests

### DIFF
--- a/test/integration/CentrifugeRouter.t.sol
+++ b/test/integration/CentrifugeRouter.t.sol
@@ -285,9 +285,9 @@ contract CentrifugeRouterTest is BaseTest {
         // multicall
         uint256 fuel = estimateGas();
         bytes[] memory calls = new bytes[](2);
-        calls[0] = abi.encodeWithSelector(router.enableLockDepositRequest.selector, address(vault_), amount);
-        calls[1] = abi.encodeWithSelector(router.executeLockedDepositRequest.selector, vault_, self, fuel);
-        router.multicall{ value: fuel }(calls);
+        calls[0] = abi.encodeCall(router.enableLockDepositRequest, (address(vault_), amount));
+        calls[1] = abi.encodeCall(router.executeLockedDepositRequest, (vault_, self, fuel));
+        router.multicall{value: fuel}(calls);
 
         uint128 assetId = poolManager.assetToId(address(erc20));
         (uint128 tranchePayout) = fulfillDepositRequest(vault, assetId, amount, self);

--- a/test/unit/CentrifugeRouter.t.sol
+++ b/test/unit/CentrifugeRouter.t.sol
@@ -120,6 +120,24 @@ contract CentrifugeRouterTest is BaseTest {
         assertEq(erc20.balanceOf(self), amount);
     }
 
+    function testUnlockDepositRequestForDisallowedAsset() public {
+        address vault_ = deploySimpleVault();
+        vm.label(vault_, "vault");
+        uint256 amount = 100 * 10 ** 18;
+        erc20.mint(self, amount);
+        erc20.approve(address(router), amount);
+        router.lockDepositRequest(vault_, amount, self, self);
+        assertEq(erc20.balanceOf(address(routerEscrow)), amount);
+        assertEq(erc20.balanceOf(self), 0);
+
+        centrifugeChain.disallowAsset(ERC7540Vault(vault_).poolId(), poolManager.assetToId(ERC7540Vault(vault_).asset()));
+        router.unlockDepositRequest(vault_, self);
+
+        assertEq(poolManager.isAllowedAsset(ERC7540Vault(vault_).poolId(), ERC7540Vault(vault_).asset()), false);
+        assertEq(erc20.balanceOf(address(routerEscrow)), 0);
+        assertEq(erc20.balanceOf(self), amount);
+    }
+
     function testCancelDepositRequest() public {
         address vault_ = deploySimpleVault();
         vm.label(vault_, "vault");

--- a/test/unit/CentrifugeRouter.t.sol
+++ b/test/unit/CentrifugeRouter.t.sol
@@ -130,7 +130,9 @@ contract CentrifugeRouterTest is BaseTest {
         assertEq(erc20.balanceOf(address(routerEscrow)), amount);
         assertEq(erc20.balanceOf(self), 0);
 
-        centrifugeChain.disallowAsset(ERC7540Vault(vault_).poolId(), poolManager.assetToId(ERC7540Vault(vault_).asset()));
+        centrifugeChain.disallowAsset(
+            ERC7540Vault(vault_).poolId(), poolManager.assetToId(ERC7540Vault(vault_).asset())
+        );
         router.unlockDepositRequest(vault_, self);
 
         assertEq(poolManager.isAllowedAsset(ERC7540Vault(vault_).poolId(), ERC7540Vault(vault_).asset()), false);


### PR DESCRIPTION
This PR adds another multicall test to reflect how the frontend will be using multicalls.
It also adds a test to verify users can call unlockDepositRequest while the asset is disallowed on the pool.