### PR TITLE
Integrations tests

### DIFF
--- a/deployments/mainnet/arbitrum-mainnet.json
+++ b/deployments/mainnet/arbitrum-mainnet.json
@@ -1,45 +1,49 @@
 {
-    "chainId": 42161,
-    "rpcUrl": "https://arbitrum-mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516",
-    "config": {
-        "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
-        "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
-        "admin": "0xa36caE0ACd40C6BbA61014282f6AE51c7807A433",
-        "adminSigners": [
-            "0xd55114BfE98a2ca16202Aa741BeE571765292616",
-            "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
-            "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
-            "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
-            "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
-            "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
-            "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
-            "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
-        ],
-        "adapter": {
-            "name": "Axelar",
-            "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
-            "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
-        },
-        "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
-        "etherscanUrl": "https://api.arbiscan.io/api/"
+  "chainId": 42161,
+  "rpcUrl": "https://arbitrum-mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516",
+  "config": {
+    "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
+    "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
+    "admin": "0xa36caE0ACd40C6BbA61014282f6AE51c7807A433",
+    "adminSigners": [
+      "0xd55114BfE98a2ca16202Aa741BeE571765292616",
+      "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
+      "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
+      "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
+      "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
+      "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
+      "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
+      "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
+    ],
+    "adapter": {
+      "name": "Axelar",
+      "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
+      "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
     },
-    "contracts": {
-        "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
-        "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
-        "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
-        "erc7540VaultFactory": "0x6f9dba3D3A3ab083BcA60Ef82784cf12A6eC24b8",
-        "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
-        "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
-        "investmentManager": "0xE79f06573d6aF1B66166A926483ba00924285d20",
-        "poolManager": "0x91808B5E2F6d7483D41A681034D7c9DbB64B9E29",
-        "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
-        "gasService": "0x3C9C09C4Cfda9D2c35142AAea706E9FC9EA28F27",
-        "gateway": "0x7829E5ca4286Df66e9F58160544097dB517a3B8c",
-        "centrifugeRouter": "0x2F445BA946044C5F508a63eEaF7EAb673c69a1F4",
-        "guardian": "0x09ab10a9c3E6Eac1d18270a2322B6113F4C7f5E8",
-        "adapter": "0x85bAFcAdeA202258e3512FFBC3E2c9eE6Ad56365"
-    },
-    "deploymentBlock": 161607032,
-    "isTestnet": false,
-    "isDeterministicallyDeployed": true
+    "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
+    "etherscanUrl": "https://api.arbiscan.io/api/"
+  },
+  "contracts": {
+    "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
+    "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
+    "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
+    "erc7540VaultFactory": "0x6f9dba3D3A3ab083BcA60Ef82784cf12A6eC24b8",
+    "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
+    "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
+    "investmentManager": "0xE79f06573d6aF1B66166A926483ba00924285d20",
+    "poolManager": "0x91808B5E2F6d7483D41A681034D7c9DbB64B9E29",
+    "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
+    "gasService": "0x3C9C09C4Cfda9D2c35142AAea706E9FC9EA28F27",
+    "gateway": "0x7829E5ca4286Df66e9F58160544097dB517a3B8c",
+    "centrifugeRouter": "0x2F445BA946044C5F508a63eEaF7EAb673c69a1F4",
+    "guardian": "0x09ab10a9c3E6Eac1d18270a2322B6113F4C7f5E8",
+    "adapter": "0x85bAFcAdeA202258e3512FFBC3E2c9eE6Ad56365"
+  },
+  "integrations": {
+    "cfg": "",
+    "verUSDC": ""
+  },
+  "deploymentBlock": 161607032,
+  "isTestnet": false,
+  "isDeterministicallyDeployed": true
 }

--- a/deployments/mainnet/arbitrum-mainnet.json
+++ b/deployments/mainnet/arbitrum-mainnet.json
@@ -1,49 +1,46 @@
 {
-  "chainId": 42161,
-  "rpcUrl": "https://arbitrum-mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516",
-  "config": {
-    "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
-    "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
-    "admin": "0xa36caE0ACd40C6BbA61014282f6AE51c7807A433",
-    "adminSigners": [
-      "0xd55114BfE98a2ca16202Aa741BeE571765292616",
-      "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
-      "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
-      "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
-      "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
-      "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
-      "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
-      "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
-    ],
-    "adapter": {
-      "name": "Axelar",
-      "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
-      "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
+    "chainId": 42161,
+    "rpcUrl": "https://arbitrum-mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516",
+    "config": {
+        "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
+        "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
+        "admin": "0xa36caE0ACd40C6BbA61014282f6AE51c7807A433",
+        "adminSigners": [
+            "0xd55114BfE98a2ca16202Aa741BeE571765292616",
+            "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
+            "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
+            "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
+            "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
+            "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
+            "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
+            "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
+        ],
+        "adapter": {
+            "name": "Axelar",
+            "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
+            "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
+        },
+        "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
+        "etherscanUrl": "https://api.arbiscan.io/api/"
     },
-    "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
-    "etherscanUrl": "https://api.arbiscan.io/api/"
-  },
-  "contracts": {
-    "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
-    "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
-    "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
-    "erc7540VaultFactory": "0x6f9dba3D3A3ab083BcA60Ef82784cf12A6eC24b8",
-    "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
-    "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
-    "investmentManager": "0xE79f06573d6aF1B66166A926483ba00924285d20",
-    "poolManager": "0x91808B5E2F6d7483D41A681034D7c9DbB64B9E29",
-    "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
-    "gasService": "0x3C9C09C4Cfda9D2c35142AAea706E9FC9EA28F27",
-    "gateway": "0x7829E5ca4286Df66e9F58160544097dB517a3B8c",
-    "centrifugeRouter": "0x2F445BA946044C5F508a63eEaF7EAb673c69a1F4",
-    "guardian": "0x09ab10a9c3E6Eac1d18270a2322B6113F4C7f5E8",
-    "adapter": "0x85bAFcAdeA202258e3512FFBC3E2c9eE6Ad56365"
-  },
-  "integrations": {
-    "cfg": "",
-    "verUSDC": ""
-  },
-  "deploymentBlock": 161607032,
-  "isTestnet": false,
-  "isDeterministicallyDeployed": true
+    "contracts": {
+        "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
+        "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
+        "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
+        "erc7540VaultFactory": "0x6f9dba3D3A3ab083BcA60Ef82784cf12A6eC24b8",
+        "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
+        "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
+        "investmentManager": "0xE79f06573d6aF1B66166A926483ba00924285d20",
+        "poolManager": "0x91808B5E2F6d7483D41A681034D7c9DbB64B9E29",
+        "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
+        "gasService": "0x3C9C09C4Cfda9D2c35142AAea706E9FC9EA28F27",
+        "gateway": "0x7829E5ca4286Df66e9F58160544097dB517a3B8c",
+        "centrifugeRouter": "0x2F445BA946044C5F508a63eEaF7EAb673c69a1F4",
+        "guardian": "0x09ab10a9c3E6Eac1d18270a2322B6113F4C7f5E8",
+        "adapter": "0x85bAFcAdeA202258e3512FFBC3E2c9eE6Ad56365"
+    },
+    "integrations": {},
+    "deploymentBlock": 161607032,
+    "isTestnet": false,
+    "isDeterministicallyDeployed": true
 }

--- a/deployments/mainnet/base-mainnet.json
+++ b/deployments/mainnet/base-mainnet.json
@@ -1,49 +1,49 @@
 {
-  "chainId": 8453,
-  "rpcUrl": "https://mainnet.base.org",
-  "config": {
-    "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
-    "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
-    "admin": "0x8b83962fB9dB346a20c95D98d4E312f17f4C0d9b",
-    "adminSigners": [
-      "0xd55114BfE98a2ca16202Aa741BeE571765292616",
-      "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
-      "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
-      "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
-      "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
-      "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
-      "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
-      "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
-    ],
-    "adapter": {
-      "name": "Axelar",
-      "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
-      "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
+    "chainId": 8453,
+    "rpcUrl": "https://mainnet.base.org",
+    "config": {
+        "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
+        "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
+        "admin": "0x8b83962fB9dB346a20c95D98d4E312f17f4C0d9b",
+        "adminSigners": [
+            "0xd55114BfE98a2ca16202Aa741BeE571765292616",
+            "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
+            "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
+            "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
+            "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
+            "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
+            "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
+            "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
+        ],
+        "adapter": {
+            "name": "Axelar",
+            "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
+            "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
+        },
+        "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
+        "etherscanUrl": "https://api.basescan.org/api/"
     },
-    "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
-    "etherscanUrl": "https://api.basescan.org/api/"
-  },
-  "contracts": {
-    "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
-    "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
-    "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
-    "erc7540VaultFactory": "0xcaD01F5A7eE9ba09A1aFDb9Dcaa58cE024E4462C",
-    "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
-    "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
-    "investmentManager": "0x36b87b860857e6a6d4c2D24be11dc9b230F00f03",
-    "poolManager": "0x7f192F34499DdB2bE06c4754CFf2a21c4B056994",
-    "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
-    "gasService": "0x32043A41F4be198C4f6590312F7A7b91624Cab57",
-    "gateway": "0x3423D288F2C04eB072eBB973F8c8B9b73cAa4361",
-    "centrifugeRouter": "0xF35501E7fC4a076E744dbAFA883CED74CCF5009d",
-    "guardian": "0x427A1ce127b1775e4Cbd4F58ad468B9F832eA7e9",
-    "adapter": "0x30e34260b895CAE34A1cfB185271628c53311cF3"
-  },
-  "integrations": {
-    "cfg": "0x2b51E2Ec9551F9B87B321f63b805871f1c81ba97",
-    "verUSDC": "0x59aaF835D34b1E3dF2170e4872B785f11E2a964b"
-  },
-  "deploymentBlock": 17854405,
-  "isTestnet": false,
-  "isDeterministicallyDeployed": true
+    "contracts": {
+        "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
+        "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
+        "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
+        "erc7540VaultFactory": "0xcaD01F5A7eE9ba09A1aFDb9Dcaa58cE024E4462C",
+        "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
+        "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
+        "investmentManager": "0x36b87b860857e6a6d4c2D24be11dc9b230F00f03",
+        "poolManager": "0x7f192F34499DdB2bE06c4754CFf2a21c4B056994",
+        "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
+        "gasService": "0x32043A41F4be198C4f6590312F7A7b91624Cab57",
+        "gateway": "0x3423D288F2C04eB072eBB973F8c8B9b73cAa4361",
+        "centrifugeRouter": "0xF35501E7fC4a076E744dbAFA883CED74CCF5009d",
+        "guardian": "0x427A1ce127b1775e4Cbd4F58ad468B9F832eA7e9",
+        "adapter": "0x30e34260b895CAE34A1cfB185271628c53311cF3"
+    },
+    "integrations": {
+        "cfg": "0x2b51E2Ec9551F9B87B321f63b805871f1c81ba97",
+        "verUSDC": "0x59aaF835D34b1E3dF2170e4872B785f11E2a964b"
+    },
+    "deploymentBlock": 17854405,
+    "isTestnet": false,
+    "isDeterministicallyDeployed": true
 }

--- a/deployments/mainnet/base-mainnet.json
+++ b/deployments/mainnet/base-mainnet.json
@@ -1,45 +1,49 @@
 {
-    "chainId": 8453,
-    "rpcUrl": "https://mainnet.base.org",
-    "config": {
-        "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
-        "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
-        "admin": "0x8b83962fB9dB346a20c95D98d4E312f17f4C0d9b",
-        "adminSigners": [
-            "0xd55114BfE98a2ca16202Aa741BeE571765292616",
-            "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
-            "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
-            "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
-            "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
-            "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
-            "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
-            "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
-        ],
-        "adapter": {
-            "name": "Axelar",
-            "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
-            "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
-        },
-        "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
-        "etherscanUrl": "https://api.basescan.org/api/"
+  "chainId": 8453,
+  "rpcUrl": "https://mainnet.base.org",
+  "config": {
+    "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
+    "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
+    "admin": "0x8b83962fB9dB346a20c95D98d4E312f17f4C0d9b",
+    "adminSigners": [
+      "0xd55114BfE98a2ca16202Aa741BeE571765292616",
+      "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
+      "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
+      "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
+      "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
+      "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
+      "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
+      "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
+    ],
+    "adapter": {
+      "name": "Axelar",
+      "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
+      "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
     },
-    "contracts": {
-        "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
-        "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
-        "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
-        "erc7540VaultFactory": "0xcaD01F5A7eE9ba09A1aFDb9Dcaa58cE024E4462C",
-        "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
-        "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
-        "investmentManager": "0x36b87b860857e6a6d4c2D24be11dc9b230F00f03",
-        "poolManager": "0x7f192F34499DdB2bE06c4754CFf2a21c4B056994",
-        "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
-        "gasService": "0x32043A41F4be198C4f6590312F7A7b91624Cab57",
-        "gateway": "0x3423D288F2C04eB072eBB973F8c8B9b73cAa4361",
-        "centrifugeRouter": "0xF35501E7fC4a076E744dbAFA883CED74CCF5009d",
-        "guardian": "0x427A1ce127b1775e4Cbd4F58ad468B9F832eA7e9",
-        "adapter": "0x30e34260b895CAE34A1cfB185271628c53311cF3"
-    },
-    "deploymentBlock": 17854405,
-    "isTestnet": false,
-    "isDeterministicallyDeployed": true
+    "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
+    "etherscanUrl": "https://api.basescan.org/api/"
+  },
+  "contracts": {
+    "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
+    "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
+    "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
+    "erc7540VaultFactory": "0xcaD01F5A7eE9ba09A1aFDb9Dcaa58cE024E4462C",
+    "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
+    "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
+    "investmentManager": "0x36b87b860857e6a6d4c2D24be11dc9b230F00f03",
+    "poolManager": "0x7f192F34499DdB2bE06c4754CFf2a21c4B056994",
+    "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
+    "gasService": "0x32043A41F4be198C4f6590312F7A7b91624Cab57",
+    "gateway": "0x3423D288F2C04eB072eBB973F8c8B9b73cAa4361",
+    "centrifugeRouter": "0xF35501E7fC4a076E744dbAFA883CED74CCF5009d",
+    "guardian": "0x427A1ce127b1775e4Cbd4F58ad468B9F832eA7e9",
+    "adapter": "0x30e34260b895CAE34A1cfB185271628c53311cF3"
+  },
+  "integrations": {
+    "cfg": "0x2b51E2Ec9551F9B87B321f63b805871f1c81ba97",
+    "verUSDC": "0x59aaF835D34b1E3dF2170e4872B785f11E2a964b"
+  },
+  "deploymentBlock": 17854405,
+  "isTestnet": false,
+  "isDeterministicallyDeployed": true
 }

--- a/deployments/mainnet/celo-mainnet.json
+++ b/deployments/mainnet/celo-mainnet.json
@@ -1,49 +1,46 @@
 {
-  "chainId": 42220,
-  "rpcUrl": "https://celo-mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516",
-  "config": {
-    "commitHash": "9f4a9a3538e78832d39ca4f6d0e5f6115eaccf38",
-    "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
-    "admin": "0x2464f95F6901233bF4a0130A3611d5B4CBd83195",
-    "adminSigners": [
-      "0xd55114BfE98a2ca16202Aa741BeE571765292616",
-      "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
-      "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
-      "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
-      "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
-      "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
-      "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
-      "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
-    ],
-    "adapter": {
-      "name": "Axelar",
-      "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
-      "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
+    "chainId": 42220,
+    "rpcUrl": "https://celo-mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516",
+    "config": {
+        "commitHash": "9f4a9a3538e78832d39ca4f6d0e5f6115eaccf38",
+        "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
+        "admin": "0x2464f95F6901233bF4a0130A3611d5B4CBd83195",
+        "adminSigners": [
+            "0xd55114BfE98a2ca16202Aa741BeE571765292616",
+            "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
+            "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
+            "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
+            "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
+            "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
+            "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
+            "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
+        ],
+        "adapter": {
+            "name": "Axelar",
+            "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
+            "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
+        },
+        "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
+        "etherscanUrl": "https://api.celoscan.io/"
     },
-    "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
-    "etherscanUrl": "https://api.celoscan.io/"
-  },
-  "contracts": {
-    "escrow": "0x9EDf9FC14DDBEE68CE1a69827b09794367180717",
-    "routerEscrow": "0xa915C288fd549e52b9e1280269929D6A91EF0c4A",
-    "root": "0x89e0E9ef81966BfA7D64BBE76394D36014a685c3",
-    "erc7540VaultFactory": "0x6b8D011EcaB5E84aAc2686eB103b33977C52Fd64",
-    "restrictionManager": "0x9d5fbC48077863d63a883f44F66aCCde72A9D4e2",
-    "trancheFactory": "0x288d01671D252eDE0878270D194e6550cF3456ce",
-    "investmentManager": "0xcaD01F5A7eE9ba09A1aFDb9Dcaa58cE024E4462C",
-    "poolManager": "0xa3Ce97352C1469884EEF3547Ec9362329FE78Cf0",
-    "transferProxyFactory": "0x453158D0b4cBd2d54B3c645f725E8fdD46c971C3",
-    "gasService": "0x36b87b860857e6a6d4c2D24be11dc9b230F00f03",
-    "gateway": "0x7f192F34499DdB2bE06c4754CFf2a21c4B056994",
-    "centrifugeRouter": "0x5a00C4fF931f37202aD4Be1FDB297E9EDc1CBb33",
-    "guardian": "0x32043A41F4be198C4f6590312F7A7b91624Cab57",
-    "adapter": "0xE4e34083a49Df72E634121f32583c9eA59191cCA"
-  },
-  "integrations": {
-    "cfg": "",
-    "verUSDC": ""
-  },
-  "deploymentBlock": 26965681,
-  "isTestnet": false,
-  "isDeterministicallyDeployed": false
+    "contracts": {
+        "escrow": "0x9EDf9FC14DDBEE68CE1a69827b09794367180717",
+        "routerEscrow": "0xa915C288fd549e52b9e1280269929D6A91EF0c4A",
+        "root": "0x89e0E9ef81966BfA7D64BBE76394D36014a685c3",
+        "erc7540VaultFactory": "0x6b8D011EcaB5E84aAc2686eB103b33977C52Fd64",
+        "restrictionManager": "0x9d5fbC48077863d63a883f44F66aCCde72A9D4e2",
+        "trancheFactory": "0x288d01671D252eDE0878270D194e6550cF3456ce",
+        "investmentManager": "0xcaD01F5A7eE9ba09A1aFDb9Dcaa58cE024E4462C",
+        "poolManager": "0xa3Ce97352C1469884EEF3547Ec9362329FE78Cf0",
+        "transferProxyFactory": "0x453158D0b4cBd2d54B3c645f725E8fdD46c971C3",
+        "gasService": "0x36b87b860857e6a6d4c2D24be11dc9b230F00f03",
+        "gateway": "0x7f192F34499DdB2bE06c4754CFf2a21c4B056994",
+        "centrifugeRouter": "0x5a00C4fF931f37202aD4Be1FDB297E9EDc1CBb33",
+        "guardian": "0x32043A41F4be198C4f6590312F7A7b91624Cab57",
+        "adapter": "0xE4e34083a49Df72E634121f32583c9eA59191cCA"
+    },
+    "integrations": {},
+    "deploymentBlock": 26965681,
+    "isTestnet": false,
+    "isDeterministicallyDeployed": false
 }

--- a/deployments/mainnet/celo-mainnet.json
+++ b/deployments/mainnet/celo-mainnet.json
@@ -1,45 +1,49 @@
 {
-    "chainId": 42220,
-    "rpcUrl": "https://celo-mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516",
-    "config": {
-        "commitHash": "9f4a9a3538e78832d39ca4f6d0e5f6115eaccf38",
-        "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
-        "admin": "0x2464f95F6901233bF4a0130A3611d5B4CBd83195",
-        "adminSigners": [
-            "0xd55114BfE98a2ca16202Aa741BeE571765292616",
-            "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
-            "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
-            "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
-            "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
-            "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
-            "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
-            "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
-        ],
-        "adapter": {
-            "name": "Axelar",
-            "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
-            "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
-        },
-        "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
-        "etherscanUrl": "https://api.celoscan.io/"
+  "chainId": 42220,
+  "rpcUrl": "https://celo-mainnet.infura.io/v3/ed5e0e19bcbc427cbf8f661736d44516",
+  "config": {
+    "commitHash": "9f4a9a3538e78832d39ca4f6d0e5f6115eaccf38",
+    "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
+    "admin": "0x2464f95F6901233bF4a0130A3611d5B4CBd83195",
+    "adminSigners": [
+      "0xd55114BfE98a2ca16202Aa741BeE571765292616",
+      "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
+      "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
+      "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
+      "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
+      "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
+      "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
+      "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
+    ],
+    "adapter": {
+      "name": "Axelar",
+      "axelarGateway": "0xe432150cce91c13a887f7D836923d5597adD8E31",
+      "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
     },
-    "contracts": {
-        "escrow": "0x9EDf9FC14DDBEE68CE1a69827b09794367180717",
-        "routerEscrow": "0xa915C288fd549e52b9e1280269929D6A91EF0c4A",
-        "root": "0x89e0E9ef81966BfA7D64BBE76394D36014a685c3",
-        "erc7540VaultFactory": "0x6b8D011EcaB5E84aAc2686eB103b33977C52Fd64",
-        "restrictionManager": "0x9d5fbC48077863d63a883f44F66aCCde72A9D4e2",
-        "trancheFactory": "0x288d01671D252eDE0878270D194e6550cF3456ce",
-        "investmentManager": "0xcaD01F5A7eE9ba09A1aFDb9Dcaa58cE024E4462C",
-        "poolManager": "0xa3Ce97352C1469884EEF3547Ec9362329FE78Cf0",
-        "transferProxyFactory": "0x453158D0b4cBd2d54B3c645f725E8fdD46c971C3",
-        "gasService": "0x36b87b860857e6a6d4c2D24be11dc9b230F00f03",
-        "gateway": "0x7f192F34499DdB2bE06c4754CFf2a21c4B056994",
-        "centrifugeRouter": "0x5a00C4fF931f37202aD4Be1FDB297E9EDc1CBb33",
-        "guardian": "0x32043A41F4be198C4f6590312F7A7b91624Cab57",
-        "adapter": "0xE4e34083a49Df72E634121f32583c9eA59191cCA"
-    },
-    "deploymentBlock": 26965681,
-    "isTestnet": false,
-    "isDeterministicallyDeployed": false
+    "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
+    "etherscanUrl": "https://api.celoscan.io/"
+  },
+  "contracts": {
+    "escrow": "0x9EDf9FC14DDBEE68CE1a69827b09794367180717",
+    "routerEscrow": "0xa915C288fd549e52b9e1280269929D6A91EF0c4A",
+    "root": "0x89e0E9ef81966BfA7D64BBE76394D36014a685c3",
+    "erc7540VaultFactory": "0x6b8D011EcaB5E84aAc2686eB103b33977C52Fd64",
+    "restrictionManager": "0x9d5fbC48077863d63a883f44F66aCCde72A9D4e2",
+    "trancheFactory": "0x288d01671D252eDE0878270D194e6550cF3456ce",
+    "investmentManager": "0xcaD01F5A7eE9ba09A1aFDb9Dcaa58cE024E4462C",
+    "poolManager": "0xa3Ce97352C1469884EEF3547Ec9362329FE78Cf0",
+    "transferProxyFactory": "0x453158D0b4cBd2d54B3c645f725E8fdD46c971C3",
+    "gasService": "0x36b87b860857e6a6d4c2D24be11dc9b230F00f03",
+    "gateway": "0x7f192F34499DdB2bE06c4754CFf2a21c4B056994",
+    "centrifugeRouter": "0x5a00C4fF931f37202aD4Be1FDB297E9EDc1CBb33",
+    "guardian": "0x32043A41F4be198C4f6590312F7A7b91624Cab57",
+    "adapter": "0xE4e34083a49Df72E634121f32583c9eA59191cCA"
+  },
+  "integrations": {
+    "cfg": "",
+    "verUSDC": ""
+  },
+  "deploymentBlock": 26965681,
+  "isTestnet": false,
+  "isDeterministicallyDeployed": false
 }

--- a/deployments/mainnet/ethereum-mainnet.json
+++ b/deployments/mainnet/ethereum-mainnet.json
@@ -1,45 +1,48 @@
 {
-    "chainId": 1,
-    "rpcUrl": "https://mainnet.infura.io/v3/28b9df37a970456197cdb6b73af4e6de",
-    "config": {
-        "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
-        "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
-        "admin": "0xD9D30ab47c0f096b0AA67e9B8B1624504a63e7FD",
-        "adminSigners": [
-            "0xd55114BfE98a2ca16202Aa741BeE571765292616",
-            "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
-            "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
-            "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
-            "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
-            "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
-            "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
-            "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
-        ],
-        "adapter": {
-            "name": "Axelar",
-            "axelarGateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5",
-            "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
-        },
-        "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
-        "etherscanUrl": "https://api.etherscan.io/api/"
+  "chainId": 1,
+  "rpcUrl": "https://mainnet.infura.io/v3/28b9df37a970456197cdb6b73af4e6de",
+  "config": {
+    "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
+    "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
+    "admin": "0xD9D30ab47c0f096b0AA67e9B8B1624504a63e7FD",
+    "adminSigners": [
+      "0xd55114BfE98a2ca16202Aa741BeE571765292616",
+      "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
+      "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
+      "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
+      "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
+      "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
+      "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
+      "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
+    ],
+    "adapter": {
+      "name": "Axelar",
+      "axelarGateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5",
+      "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
     },
-    "contracts": {
-        "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
-        "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
-        "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
-        "erc7540VaultFactory": "0x6f9dba3D3A3ab083BcA60Ef82784cf12A6eC24b8",
-        "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
-        "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
-        "investmentManager": "0xE79f06573d6aF1B66166A926483ba00924285d20",
-        "poolManager": "0x91808B5E2F6d7483D41A681034D7c9DbB64B9E29",
-        "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
-        "gasService": "0x3C9C09C4Cfda9D2c35142AAea706E9FC9EA28F27",
-        "gateway": "0x7829E5ca4286Df66e9F58160544097dB517a3B8c",
-        "centrifugeRouter": "0x2F445BA946044C5F508a63eEaF7EAb673c69a1F4",
-        "guardian": "0x09ab10a9c3E6Eac1d18270a2322B6113F4C7f5E8",
-        "adapter": "0x85bAFcAdeA202258e3512FFBC3E2c9eE6Ad56365"
-    },
-    "deploymentBlock": 20432396,
-    "isTestnet": false,
-    "isDeterministicallyDeployed": true
+    "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
+    "etherscanUrl": "https://api.etherscan.io/api/"
+  },
+  "contracts": {
+    "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
+    "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
+    "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
+    "erc7540VaultFactory": "0x6f9dba3D3A3ab083BcA60Ef82784cf12A6eC24b8",
+    "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
+    "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
+    "investmentManager": "0xE79f06573d6aF1B66166A926483ba00924285d20",
+    "poolManager": "0x91808B5E2F6d7483D41A681034D7c9DbB64B9E29",
+    "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
+    "gasService": "0x3C9C09C4Cfda9D2c35142AAea706E9FC9EA28F27",
+    "gateway": "0x7829E5ca4286Df66e9F58160544097dB517a3B8c",
+    "centrifugeRouter": "0x2F445BA946044C5F508a63eEaF7EAb673c69a1F4",
+    "guardian": "0x09ab10a9c3E6Eac1d18270a2322B6113F4C7f5E8",
+    "adapter": "0x85bAFcAdeA202258e3512FFBC3E2c9eE6Ad56365"
+  },
+  "integrations": {
+    "cfg": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0"
+  },
+  "deploymentBlock": 20432396,
+  "isTestnet": false,
+  "isDeterministicallyDeployed": true
 }

--- a/deployments/mainnet/ethereum-mainnet.json
+++ b/deployments/mainnet/ethereum-mainnet.json
@@ -1,49 +1,48 @@
 {
-  "chainId": 1,
-  "rpcUrl": "https://mainnet.infura.io/v3/28b9df37a970456197cdb6b73af4e6de",
-  "config": {
-    "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
-    "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
-    "admin": "0xD9D30ab47c0f096b0AA67e9B8B1624504a63e7FD",
-    "adminSigners": [
-      "0xd55114BfE98a2ca16202Aa741BeE571765292616",
-      "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
-      "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
-      "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
-      "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
-      "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
-      "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
-      "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
-    ],
-    "adapter": {
-      "name": "Axelar",
-      "axelarGateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5",
-      "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
+    "chainId": 1,
+    "rpcUrl": "https://mainnet.infura.io/v3/28b9df37a970456197cdb6b73af4e6de",
+    "config": {
+        "commitHash": "7b367a604bcf3bf7de5afb1bcfd956f922669779",
+        "deployer": "0x7270b20603FbB3dF0921381670fbd62b9991aDa4",
+        "admin": "0xD9D30ab47c0f096b0AA67e9B8B1624504a63e7FD",
+        "adminSigners": [
+            "0xd55114BfE98a2ca16202Aa741BeE571765292616",
+            "0x6E72DD4D5CFCc274a8712A72C9dB9FE1d5A7eB6b",
+            "0x88b991A2A8d3C5Ac808D3471e1784C6165d29612",
+            "0xE9441B34f71659cCA2bfE90d98ee0e57D9CAD28F",
+            "0x2F1724cc5005F376411747dFE24fb7412f5955B1",
+            "0x9eDec77dd2651Ce062ab17e941347018AD4eAEA9",
+            "0x790c2c860DDC993f3da92B19cB440cF8338C59a6",
+            "0xc4576CE4603552c5BeAa056c449b0795D48fcf92"
+        ],
+        "adapter": {
+            "name": "Axelar",
+            "axelarGateway": "0x4F4495243837681061C4743b74B3eEdf548D56A5",
+            "axelarGasService": "0x2d5d7d31F671F86C782533cc367F14109a082712"
+        },
+        "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
+        "etherscanUrl": "https://api.etherscan.io/api/"
     },
-    "deploymentSalt": "0x7270b20603fbb3df0921381670fbd62b9991ada4b17953a73f70fdff36730018",
-    "etherscanUrl": "https://api.etherscan.io/api/"
-  },
-  "contracts": {
-    "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
-    "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
-    "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
-    "erc7540VaultFactory": "0x6f9dba3D3A3ab083BcA60Ef82784cf12A6eC24b8",
-    "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
-    "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
-    "investmentManager": "0xE79f06573d6aF1B66166A926483ba00924285d20",
-    "poolManager": "0x91808B5E2F6d7483D41A681034D7c9DbB64B9E29",
-    "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
-    "gasService": "0x3C9C09C4Cfda9D2c35142AAea706E9FC9EA28F27",
-    "gateway": "0x7829E5ca4286Df66e9F58160544097dB517a3B8c",
-    "centrifugeRouter": "0x2F445BA946044C5F508a63eEaF7EAb673c69a1F4",
-    "guardian": "0x09ab10a9c3E6Eac1d18270a2322B6113F4C7f5E8",
-    "adapter": "0x85bAFcAdeA202258e3512FFBC3E2c9eE6Ad56365"
-  },
-  "integrations": {
-    "cfg": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0",
-    "verUSDC": ""
-  },
-  "deploymentBlock": 20432396,
-  "isTestnet": false,
-  "isDeterministicallyDeployed": true
+    "contracts": {
+        "escrow": "0x0000000005F458Fd6ba9EEb5f365D83b7dA913dD",
+        "routerEscrow": "0x0F1b890fC6774Ef9b14e99de16302E24A6e7B4F7",
+        "root": "0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC",
+        "erc7540VaultFactory": "0x6f9dba3D3A3ab083BcA60Ef82784cf12A6eC24b8",
+        "restrictionManager": "0x4737C3f62Cc265e786b280153fC666cEA2fBc0c0",
+        "trancheFactory": "0xFa072fB96F737bdBCEa28c921d43c34d3a4Dbb6C",
+        "investmentManager": "0xE79f06573d6aF1B66166A926483ba00924285d20",
+        "poolManager": "0x91808B5E2F6d7483D41A681034D7c9DbB64B9E29",
+        "transferProxyFactory": "0xbe55eBC29344a26550E07EF59aeF791fA3b2A817",
+        "gasService": "0x3C9C09C4Cfda9D2c35142AAea706E9FC9EA28F27",
+        "gateway": "0x7829E5ca4286Df66e9F58160544097dB517a3B8c",
+        "centrifugeRouter": "0x2F445BA946044C5F508a63eEaF7EAb673c69a1F4",
+        "guardian": "0x09ab10a9c3E6Eac1d18270a2322B6113F4C7f5E8",
+        "adapter": "0x85bAFcAdeA202258e3512FFBC3E2c9eE6Ad56365"
+    },
+    "integrations": {
+        "cfg": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0"
+    },
+    "deploymentBlock": 20432396,
+    "isTestnet": false,
+    "isDeterministicallyDeployed": true
 }

--- a/deployments/mainnet/ethereum-mainnet.json
+++ b/deployments/mainnet/ethereum-mainnet.json
@@ -40,7 +40,8 @@
     "adapter": "0x85bAFcAdeA202258e3512FFBC3E2c9eE6Ad56365"
   },
   "integrations": {
-    "cfg": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0"
+    "cfg": "0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0",
+    "verUSDC": ""
   },
   "deploymentBlock": 20432396,
   "isTestnet": false,

--- a/test/fork/Fork.t.sol
+++ b/test/fork/Fork.t.sol
@@ -479,11 +479,11 @@ contract ForkTest is Test {
                 address admin = _get(i, ".config.admin");
                 _loadFork(i);
 
-                if (verUSDC != address(0)) {
+                if (verUSDC != address(32)) {
                     assertTrue(IAuth(verUSDC).wards(root) == 1);
                     assertTrue(IAuth(IWrappedUSDC(verUSDC).memberlist()).wards(admin) == 1);
                 }
-                if (cfg != address(0)) {
+                if (cfg != address(32)) {
                     assertTrue(IAuth(cfg).wards(root) == 1);
                 }
             }

--- a/test/fork/Fork.t.sol
+++ b/test/fork/Fork.t.sol
@@ -60,6 +60,7 @@ struct Deployment {
 contract ForkTest is Test {
     using stdJson for string;
 
+    // Address that is used to denote an unset address when parsing deployment JSONs
     address constant UNSET_ADDRESS = address(32);
 
     string[] deployments;

--- a/test/fork/Fork.t.sol
+++ b/test/fork/Fork.t.sol
@@ -440,6 +440,14 @@ contract ForkTest is Test {
     }
 
     function _getAddress(uint256 id, string memory key) public view returns (address) {
+        try this._tryGetAddress(id, key) returns (address addr) {
+            return addr;
+        } catch {
+            return address(0);
+        }
+    }
+
+    function _tryGetAddress(uint256 id, string memory key) external view returns (address) {
         return abi.decode(deployments[id].parseRaw(key), (address));
     }
 
@@ -475,18 +483,8 @@ contract ForkTest is Test {
         if (vm.envOr("FORK_TESTS", false)) {
             for (uint256 i = 0; i < deployments.length; i++) {
                 uint256 chainId = _getUint256(i, ".chainId");
-                address cfg;
-                try this._getAddress(i, ".integrations.cfg") returns (address _cfg) {
-                    cfg = _cfg;
-                } catch {
-                    cfg = address(0);
-                }
-                address verUSDC;
-                try this._getAddress(i, ".integrations.verUSDC") returns (address _verUSDC) {
-                    verUSDC = _verUSDC;
-                } catch {
-                    verUSDC = address(0);
-                }
+                address cfg = _getAddress(i, ".integrations.cfg");
+                address verUSDC = _getAddress(i, ".integrations.verUSDC");
                 address root = _getAddress(i, ".contracts.root");
                 address admin = _getAddress(i, ".config.admin");
                 _loadFork(i);


### PR DESCRIPTION
This PR adds liquidity pools integrations to the deployments and fork tests. For now, these include CFG and verUSDC, and the tests just verify the wards are set correctly on each.